### PR TITLE
✨ feat: Let Field.Control take an element, and put releases on Changesets

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,17 @@
+# Changesets
+
+A release is described here before it happens, one file per change.
+
+```bash
+pnpm changeset          # write one: pick the packages, pick the bump, say why
+pnpm version-packages   # spend them: bumps versions, writes CHANGELOG.md, deletes the files
+pnpm release            # build and publish whatever changed
+```
+
+The point is that the version number stops being a decision made at release
+time from memory. Each change says what it is when it is still fresh, and the
+release is the sum of those.
+
+`base-react` and `behavior-react` went unchanged through 1.1.0 and were not
+republished. That stays true here without anyone having to remember it:
+a package with no changeset gets no version.

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -4,14 +4,47 @@ A release is described here before it happens, one file per change.
 
 ```bash
 pnpm changeset          # write one: pick the packages, pick the bump, say why
-pnpm version-packages   # spend them: bumps versions, writes CHANGELOG.md, deletes the files
-pnpm release            # build and publish whatever changed
 ```
 
-The point is that the version number stops being a decision made at release
-time from memory. Each change says what it is when it is still fresh, and the
-release is the sum of those.
+The point is that the version number stops being a decision made at release time
+from memory. Each change says what it is when it is still fresh, and the release
+is the sum of those.
 
 `base-react` and `behavior-react` went unchanged through 1.1.0 and were not
-republished. That stays true here without anyone having to remember it:
-a package with no changeset gets no version.
+republished. That stays true here without anyone having to remember it: a
+package with no changeset gets no version, and a package that only depends on
+one that moved gets the bump `updateInternalDependencies` asks for.
+
+## Releasing
+
+```bash
+pnpm version-packages                    # spend the changesets: versions, CHANGELOG.md
+git commit -am "chore: version packages" # the bump is a commit, so git can answer "when"
+pnpm release                             # build, publish, and tag each package
+```
+
+`pnpm release` tags every package it publishes, `components-react@1.2.0` and so
+on. Those say which package is at which version, which one tag for the whole
+repository cannot.
+
+Then one more tag for the release as a whole, because a GitHub Release needs
+something to hang on and a reader looking for "what shipped in August" is not
+looking for four package tags:
+
+```bash
+git tag -a v1.2.0 -m "components-react 1.2.0, style-tokens 1.0.2"
+git push --follow-tags
+gh release create v1.2.0 --title v1.2.0 --notes-file <(…)
+```
+
+The repository tag mirrors `components-react`, which is the package anyone
+installs first. Keep the root `package.json` version on it too — nothing reads
+that number, and letting it drift makes it a lie rather than a spare.
+
+## Later
+
+`changesets/action` does the middle of this: it watches `main` for pending
+changesets, opens a "Version Packages" pull request with the bumps and
+changelogs already written, and publishes when that is merged. Worth adding once
+the manual run has been done at least once, so it is clear what the action is
+standing in for.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "linked": [],
+  "ignore": []
+}

--- a/.changeset/tame-pugs-look.md
+++ b/.changeset/tame-pugs-look.md
@@ -1,0 +1,26 @@
+---
+'@minuk-hwang-design-system/components-react': minor
+---
+
+`Field.Control` accepts an element as well as a render function
+
+A function cannot cross the React Server Components boundary — React refuses it
+with "Functions cannot be passed directly to Client Components" — so the render
+prop left `Field` as the one component in the package that could not be rendered
+from a server component at all. The README said the opposite: that a namespace
+import works on either side of the boundary. It does; `Field.Control` was what
+stopped there.
+
+Passing a single element clones the generated props onto it, so this works from
+a server component:
+
+```tsx
+<Field.Control>
+  <Input placeholder="@scope/name" />
+</Field.Control>
+```
+
+The render prop is unchanged and stays the form the documentation shows. It is
+the only thing that works for a control the system has never seen, since cloning
+guesses at the child's API. The element's own props win the merge, so a caller
+who writes `disabled` or an `id` keeps it.

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ pnpm dev:docs            # the documentation site
 
 ## 👤 Author
 
-**Minuk Hwang** - Frontend Developer
+**Minuk Hwang** - Fullstack Developer
 
-- 📚 [Documentation](https://ds.minukhwang.com)
+- 🌐 [Portfolio](https://www.minukhwang.com)
 - 💼 [LinkedIn](https://linkedin.com/in/minuk-hwang-934999157)
 - 📧 [minuk.lucas.hwang@gmail.com](mailto:minuk.lucas.hwang@gmail.com)

--- a/apps/docs/app/components/field/content.tsx
+++ b/apps/docs/app/components/field/content.tsx
@@ -57,6 +57,30 @@ export default function FieldPage() {
       </Callout>
 
       <Preview
+        title="From a server component"
+        description="Pass a single element instead, and the props are cloned onto it. A function cannot cross the server boundary, so this is the form to reach for there."
+        stack
+        code={`<Field.Root required>
+  <Field.Label>Package name</Field.Label>
+  <Field.Control>
+    <Input placeholder="@scope/name" />
+  </Field.Control>
+</Field.Root>`}
+      >
+        <Field.Root required>
+          <Field.Label>Package name</Field.Label>
+          <Field.Control>
+            <Input placeholder="@scope/name" />
+          </Field.Control>
+        </Field.Root>
+      </Preview>
+
+      <Callout tone="warning">
+        The render function stays the better form for anything the system has not seen. Cloning
+        guesses at a child&apos;s API; handing the props over does not.
+      </Callout>
+
+      <Preview
         title="Invalid"
         description='Field.Error renders nothing while the root is valid, and carries role="alert" when it appears.'
         stack

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -225,11 +225,29 @@ code {
 /*
  * Focus is never removed, only redrawn. The one rule of a docs site nobody
  * checks is whether it can be read with a keyboard.
+ *
+ * No `border-radius` here, and that is the point of the comment.
+ *
+ * It used to set one, so that a focused bare element had a shape. Every
+ * component in the system is focusable too, and none of them declare a radius
+ * inside their own `:focus` rule — they declare it once on the element and
+ * expect it to hold. So this rule had no competitor and won: focusing an input
+ * at `radius="full"` turned a pill into a 4px rectangle, and every other
+ * control lost its corners the same way the moment it was focused.
+ *
+ * `:where()` for the same reason, and it is not decoration either. A bare
+ * `:focus-visible` counts the same as a component's class, and the component
+ * bundle arrives through an `@import` at the top of this file — so on a tie the
+ * site won, and a menu row that had set `outline: none` because highlighting is
+ * its focus indicator got an outline anyway. Offset two pixels outward, where
+ * the panel clipped its sides and left two green bars.
+ *
+ * At zero specificity this is what it was meant to be: a floor for the site's
+ * own bare elements, which anything with an opinion of its own overrides.
  */
-:focus-visible {
+:where(:focus-visible) {
   outline: 2px solid var(--border-focus);
   outline-offset: 2px;
-  border-radius: var(--docs-radius-4);
 }
 
 ::selection {

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -7,6 +7,7 @@ import { DialsProvider } from '../site/dials';
 import { NavProvider } from '../site/nav-state';
 import { SITE } from '../site/page-metadata';
 import { RepositoryLink } from '../site/RepositoryLink';
+import { ScrollReset } from '../site/ScrollReset';
 import { Brand, MenuButton, Sidebar } from '../site/Sidebar';
 import { Toolbar } from '../site/Toolbar';
 
@@ -160,6 +161,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className={css.shell}>
               <Sidebar />
               <main className={css.main}>
+                <ScrollReset />
                 <div className={css.content}>{children}</div>
               </main>
             </div>

--- a/apps/docs/site/ScrollReset.tsx
+++ b/apps/docs/site/ScrollReset.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+/*
+ * Back to the top on every navigation.
+ *
+ * Next resets the window's scroll between routes, and the window is not what
+ * scrolls here: `.main` is the scroll container, so the article kept whatever
+ * offset the last page left it at. Landing halfway down a page you have never
+ * read is the kind of thing that reads as a broken link.
+ *
+ * It finds the container by walking up from its own node rather than by id, so
+ * the day the layout changes which element scrolls, this follows.
+ *
+ * `useLayoutEffect` because the reset has to happen before the browser paints —
+ * in an effect the new page is shown at the old offset for a frame first.
+ */
+import { usePathname } from 'next/navigation';
+import * as React from 'react';
+
+const scrollParent = (node: HTMLElement | null) => {
+  for (let el = node?.parentElement; el; el = el.parentElement) {
+    const { overflowY } = getComputedStyle(el);
+    if (overflowY === 'auto' || overflowY === 'scroll') return el;
+  }
+  return null;
+};
+
+export const ScrollReset = () => {
+  const pathname = usePathname();
+  const marker = React.useRef<HTMLSpanElement>(null);
+
+  React.useLayoutEffect(() => {
+    scrollParent(marker.current)?.scrollTo({ top: 0 });
+    // The window too, for the widths where the article is not its own scroller.
+    window.scrollTo({ top: 0 });
+  }, [pathname]);
+
+  return <span ref={marker} aria-hidden="true" />;
+};

--- a/apps/docs/site/Toolbar.tsx
+++ b/apps/docs/site/Toolbar.tsx
@@ -117,27 +117,25 @@ export const Toolbar = () => {
           >
             gray
           </Text>
-          <Select.Root
-            value={neutral}
-            onValueChange={(value: string) => setNeutral(value as NeutralColor)}
-          >
-            <Select.Trigger
-              aria-labelledby="neutral-dial-label"
-              size="s"
-              className={css.radiusTrigger}
+          <div className={css.dialSelect}>
+            <Select.Root
+              value={neutral}
+              onValueChange={(value: string) => setNeutral(value as NeutralColor)}
             >
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Content>
-              <Select.Group>
-                {neutralColors.map(family => (
-                  <Select.Item key={family} value={family}>
-                    {family}
-                  </Select.Item>
-                ))}
-              </Select.Group>
-            </Select.Content>
-          </Select.Root>
+              <Select.Trigger aria-labelledby="neutral-dial-label" size="s">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Content>
+                <Select.Group>
+                  {neutralColors.map(family => (
+                    <Select.Item key={family} value={family}>
+                      {family}
+                    </Select.Item>
+                  ))}
+                </Select.Group>
+              </Select.Content>
+            </Select.Root>
+          </div>
         </div>
 
         {/*
@@ -161,27 +159,25 @@ export const Toolbar = () => {
           >
             radius
           </Text>
-          <Select.Root
-            value={radius}
-            onValueChange={(value: string) => setRadius(value as RadiusScale)}
-          >
-            <Select.Trigger
-              aria-labelledby="radius-dial-label"
-              size="s"
-              className={css.radiusTrigger}
+          <div className={css.dialSelect}>
+            <Select.Root
+              value={radius}
+              onValueChange={(value: string) => setRadius(value as RadiusScale)}
             >
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Content>
-              <Select.Group>
-                {radiusScales.map(scale => (
-                  <Select.Item key={scale} value={scale}>
-                    {scale}
-                  </Select.Item>
-                ))}
-              </Select.Group>
-            </Select.Content>
-          </Select.Root>
+              <Select.Trigger aria-labelledby="radius-dial-label" size="s">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Content>
+                <Select.Group>
+                  {radiusScales.map(scale => (
+                    <Select.Item key={scale} value={scale}>
+                      {scale}
+                    </Select.Item>
+                  ))}
+                </Select.Group>
+              </Select.Content>
+            </Select.Root>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/docs/site/chrome.module.css
+++ b/apps/docs/site/chrome.module.css
@@ -446,6 +446,14 @@
  * Four, from the widest ring in the row rather than from the narrowest: the
  * buttons beside the selects sit their outline two pixels out and draw two more,
  * where a select's crosses its own border and needs one.
+ *
+ * The sides need the same four and for the same reason, which is less obvious
+ * because only one control is ever against an edge. The last dial lost the
+ * right-hand side of its ring and nothing else did, so it read as a bug in that
+ * control rather than in the row holding it.
+ *
+ * The negative margin hands those pixels back, so the row sits where it always
+ * did and only the clip moved.
  */
 .toolbarRow {
   display: flex;
@@ -453,6 +461,8 @@
   flex-wrap: nowrap;
   gap: var(--spacing-10);
   padding-block: var(--spacing-4);
+  padding-inline: 4px;
+  margin-inline: -4px;
   overflow-x: auto;
   scrollbar-width: none;
 }
@@ -523,8 +533,23 @@
     0 0 0 4px var(--accent-500);
 }
 
-.radiusTrigger {
+/*
+ * A box around the select rather than a width on it.
+ *
+ * `Select`'s trigger is `width: 100%`, which fills a block parent and means
+ * nothing in a flex row — there it falls back to the content, so the control
+ * grew and shrank as the value went from `none` to `medium` and everything to
+ * its right moved with it. Styling the trigger directly is a fight the consumer
+ * loses: one class ties with the component's own and the package's stylesheet
+ * is read last.
+ *
+ * A wrapper sidesteps both. It is the consumer's own element, so nothing
+ * competes for it, and the trigger fills it because filling its parent is what
+ * the trigger already does. 116 fits the longest label at this size.
+ */
+.dialSelect {
   width: 116px;
+  flex: none;
 }
 
 /*

--- a/apps/docs/site/tokens.module.css
+++ b/apps/docs/site/tokens.module.css
@@ -358,18 +358,34 @@
 
 /* ── type specimen ──────────────────────────────────────────── */
 
+/*
+ * Centered, not on the baseline.
+ *
+ * Baseline put the meta block's first line on the specimen's baseline, which is
+ * right when the label is one line and wrong here: the second line then hangs
+ * below it, and beside a 60px sample the pair reads as having slipped to the
+ * floor. What this row compares is size, and the label is a block rather than a
+ * sentence, so it centers — the same call the elevation rows already record.
+ */
 .stepRow {
   display: grid;
   grid-template-columns: 150px minmax(0, 1fr);
   gap: var(--spacing-16);
-  align-items: baseline;
+  align-items: center;
   width: 100%;
 }
 
 .stepMeta {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-2);
+  /*
+   * Six, where it was two.
+   *
+   * The chip above carries two pixels of its own padding, so a two-pixel gap put
+   * its box within four of the line under it and the pair read as one smudged
+   * block rather than as a name and its measurement.
+   */
+  gap: var(--spacing-6);
   font-size: var(--font-size-13);
   color: var(--text-color-normal);
 }
@@ -417,7 +433,7 @@
   }
 
   .stepMeta {
-    gap: var(--spacing-4);
+    gap: var(--spacing-8);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "changeset": "changeset",
+    "version-packages": "changeset version",
+    "release": "pnpm build:packages && changeset publish",
     "publish:tokens": "pnpm --filter @minuk-hwang-design-system/style-tokens build && pnpm --filter @minuk-hwang-design-system/style-tokens publish --access public --no-git-checks",
     "publish:behavior": "pnpm --filter @minuk-hwang-design-system/behavior-react build && pnpm --filter @minuk-hwang-design-system/behavior-react publish --access public --no-git-checks",
     "publish:base": "pnpm --filter @minuk-hwang-design-system/base-react build && pnpm --filter @minuk-hwang-design-system/base-react publish --access public --no-git-checks",
@@ -46,6 +49,7 @@
   "license": "MIT",
   "packageManager": "pnpm@8.15.0",
   "devDependencies": {
+    "@changesets/cli": "^3.0.0",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@typescript-eslint/eslint-plugin": "^8.43.0",

--- a/packages/components/react/src/field/index.tsx
+++ b/packages/components/react/src/field/index.tsx
@@ -56,14 +56,31 @@ export type FieldRootProps = React.HTMLAttributes<HTMLDivElement> & {
   required?: boolean;
 };
 
+/** What `Field.Root` works out and hands to whatever the control turns out to be. */
+export type FieldControlRenderProps = {
+  id: string;
+  'aria-describedby': string | undefined;
+  'aria-invalid': true | undefined;
+  disabled: boolean;
+  required: boolean;
+};
+
 export type FieldControlProps = {
-  children: (props: {
-    id: string;
-    'aria-describedby': string | undefined;
-    'aria-invalid': true | undefined;
-    disabled: boolean;
-    required: boolean;
-  }) => React.ReactNode;
+  /**
+   * A function, or a single element to clone the props onto.
+   *
+   * The function is the better form and stays the one the documentation shows:
+   * it hands the props over and lets the caller spread them wherever they
+   * belong, which is the only thing that works for a control the system has
+   * never seen.
+   *
+   * The element form exists because a function cannot cross the React Server
+   * Components boundary. Passing one from a server component fails outright
+   * with "Functions cannot be passed directly to Client Components", so the
+   * render prop made `Field` the one component in the package that could not be
+   * rendered from a server component at all.
+   */
+  children: React.ReactElement | ((props: FieldControlRenderProps) => React.ReactNode);
 };
 
 /*
@@ -154,6 +171,17 @@ export const FieldLabel = React.forwardRef<
  * `textarea`, a `Select` or something the system has never seen. Cloning an
  * unknown child to inject props guesses at its API; handing the props over lets
  * the caller spread them wherever they belong.
+ *
+ * A single element is accepted too, and then the props are cloned onto it. That
+ * is the guess the paragraph above declines to make, and it is here because the
+ * alternative was worse: a function cannot cross the server boundary, so the
+ * render prop alone left `Field` unusable from a server component while every
+ * other component in the package renders there or says it does not.
+ *
+ * The element's own props win the merge. `id` from `Field` is the wiring the
+ * label depends on, but a caller who writes one has said something deliberate,
+ * and `disabled`/`required` are only overridden when written out — an element
+ * that does not mention them takes the field's.
  */
 const Control = ({ children }: FieldControlProps) => {
   const {
@@ -172,15 +200,19 @@ const Control = ({ children }: FieldControlProps) => {
       .filter(Boolean)
       .join(' ') || undefined;
 
+  const controlProps: FieldControlRenderProps = {
+    id: controlId,
+    'aria-describedby': describedBy,
+    'aria-invalid': invalid || undefined,
+    disabled,
+    required,
+  };
+
   return (
     <>
-      {children({
-        id: controlId,
-        'aria-describedby': describedBy,
-        'aria-invalid': invalid || undefined,
-        disabled,
-        required,
-      })}
+      {typeof children === 'function'
+        ? children(controlProps)
+        : React.cloneElement(children, { ...controlProps, ...children.props })}
     </>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@changesets/cli':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@commitlint/cli':
         specifier: ^19.8.1
         version: 19.8.1(@types/node@22.20.1)(typescript@5.9.2)
@@ -465,6 +468,174 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+    dev: true
+
+  /@changesets/apply-release-plan@8.0.0:
+    resolution: {integrity: sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/config': 4.0.0
+      '@changesets/format': 0.1.2
+      '@changesets/git': 4.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      import-meta-resolve: 4.2.0
+      jsonc-parser: 3.3.1
+      semver: 7.8.5
+    dev: true
+
+  /@changesets/assemble-release-plan@7.0.0:
+    resolution: {integrity: sha512-oEW8BxdA604kGGtDSCiHr5w9Tv4UWe9I2k61IBNZzCOE1kbYaJj4v+lFQNgcEZFkUc2pV/+hASErGDvpJOZCTg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      semver: 7.8.5
+    dev: true
+
+  /@changesets/changelog-git@1.0.0:
+    resolution: {integrity: sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/types': 7.0.0
+    dev: true
+
+  /@changesets/cli@3.0.0:
+    resolution: {integrity: sha512-V7Gm+GP5OT3mJinMI2YcJD/JyO/a4WChnaMCCzTRhWHgu1zhtsyY7zCjP6n5W6zsgSjJKs+yPmvtREvE0F2g8A==}
+    engines: {node: ^22.11 || ^24 || >=26, npm: '>=10.9.0', pnpm: '>=10.0.0', yarn: '>=4.5.2'}
+    hasBin: true
+    dependencies:
+      '@changesets/apply-release-plan': 8.0.0
+      '@changesets/assemble-release-plan': 7.0.0
+      '@changesets/changelog-git': 1.0.0
+      '@changesets/config': 4.0.0
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/git': 4.0.0
+      '@changesets/pre': 3.0.0
+      '@changesets/read': 1.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@changesets/write': 1.0.0
+      '@clack/prompts': 1.7.0
+      '@manypkg/get-packages': 3.1.0
+      '@pnpm/deps.graph-sequencer': 1100.0.1
+      cac: 7.0.0
+      import-meta-resolve: 4.2.0
+      launch-editor: 2.14.1
+      package-manager-detector: 1.8.0
+      semver: 7.8.5
+      tinyexec: 1.3.0
+    dev: true
+
+  /@changesets/config@4.0.0:
+    resolution: {integrity: sha512-mw95/YrkOuhZZxfnVAA4bSXOFUi+KlhzOBTM8C4x777NhUU6HWIl9Z+K+nME+E4PVsv5NQVQwTfiHihAS1A/ow==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.5
+    dev: true
+
+  /@changesets/errors@1.0.0:
+    resolution: {integrity: sha512-ElN/mEzn6zmETgjwf5MclCMa9ef59sAR0lfO8VSYIsiRvbC2FbLB/92EoYw10Sl0kGixxHFiJZUSv7dA+YpR8g==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dev: true
+
+  /@changesets/format@0.1.2:
+    resolution: {integrity: sha512-Caez5XtNXCFS/G5bwyav3wuXL0tMxVd2ZGbaumWbzN08tyzO21asCw7JZhNtVsAZDCvDRUzZN+Iit9SyRITSYA==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
+    dev: true
+
+  /@changesets/get-dependents-graph@3.0.0:
+    resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/types': 7.0.0
+      semver: 7.8.5
+    dev: true
+
+  /@changesets/git@4.0.0:
+    resolution: {integrity: sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.5
+      tinyexec: 1.3.0
+    dev: true
+
+  /@changesets/parse@1.0.0:
+    resolution: {integrity: sha512-P0iaMb9p9CRYZiTgAllEIF9AUMQHIy1G72tKlcIqJp61icZSsKQNiOPdxAMZG8m/DvZwt/oz5xEbTpike//dWg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/types': 7.0.0
+      yaml: 2.9.0
+    dev: true
+
+  /@changesets/pre@3.0.0:
+    resolution: {integrity: sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+    dev: true
+
+  /@changesets/read@1.0.0:
+    resolution: {integrity: sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/git': 4.0.0
+      '@changesets/parse': 1.0.0
+      '@changesets/types': 7.0.0
+    dev: true
+
+  /@changesets/should-skip-package@1.0.0:
+    resolution: {integrity: sha512-pwqoJmbONn1XgXmZXPEExgAaT+HdZLjALFTDgIm+PnS5KeO2nLtzA2/Q+4aMFY14kFMuXKG30MObhvDzWgzDgg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/types': 7.0.0
+    dev: true
+
+  /@changesets/types@7.0.0:
+    resolution: {integrity: sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dev: true
+
+  /@changesets/write@1.0.0:
+    resolution: {integrity: sha512-xCK3/4C7Z7muQB/wguE6HcbjtY9iOtaK9orZKE+7xi573cMGD8rLZz7qlo6IvK7s+SIUIKajzj1l+F1QuP97tw==}
+    engines: {node: ^22.11 || ^24 || >=26}
+    dependencies:
+      '@changesets/format': 0.1.2
+      '@changesets/types': 7.0.0
+      human-id: 4.2.0
+    dev: true
+
+  /@clack/core@1.4.3:
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+    dev: true
+
+  /@clack/prompts@1.7.0:
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
     dev: true
 
   /@commitlint/cli@19.8.1(@types/node@22.20.1)(typescript@5.9.2):
@@ -1271,6 +1442,30 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
+  /@manypkg/find-root@3.1.0:
+    resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@manypkg/tools': 2.1.2
+    dev: true
+
+  /@manypkg/get-packages@3.1.0:
+    resolution: {integrity: sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@manypkg/find-root': 3.1.0
+      '@manypkg/tools': 2.1.2
+    dev: true
+
+  /@manypkg/tools@2.1.2:
+    resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      jju: 1.4.0
+      tinyglobby: 0.2.17
+      yaml: 2.9.0
+    dev: true
+
   /@napi-rs/wasm-runtime@0.2.12:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
@@ -1478,6 +1673,11 @@ packages:
   /@pnpm/config.env-replace@1.1.0:
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
+    dev: true
+
+  /@pnpm/deps.graph-sequencer@1100.0.1:
+    resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
+    engines: {node: '>=22.13'}
     dev: true
 
   /@pnpm/network.ca-file@1.0.2:
@@ -3461,6 +3661,11 @@ packages:
       ieee754: 1.2.1
     dev: true
 
+  /cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
+    dev: true
+
   /call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -4641,8 +4846,24 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+    dev: true
+
+  /fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+    dev: true
+
   /fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+    dev: true
+
+  /fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+    dependencies:
+      fast-string-width: 3.0.2
     dev: true
 
   /fastq@1.19.1:
@@ -5104,6 +5325,11 @@ packages:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /human-id@4.2.0:
+    resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
+    hasBin: true
     dev: true
 
   /human-signals@5.0.0:
@@ -5577,6 +5803,10 @@ packages:
     hasBin: true
     dev: true
 
+  /jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+    dev: true
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5651,6 +5881,10 @@ packages:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
+  /jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+    dev: true
+
   /jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
@@ -5693,6 +5927,13 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       package-json: 10.0.1
+    dev: true
+
+  /launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.10.0
     dev: true
 
   /levn@0.4.1:
@@ -6528,6 +6769,10 @@ packages:
       semver: 7.7.2
     dev: true
 
+  /package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+    dev: true
+
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -7071,8 +7316,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     requiresBuild: true
-    dev: false
-    optional: true
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7153,6 +7396,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -7204,6 +7452,10 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+    dev: true
+
+  /sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
 
   /slash@3.0.0:
@@ -8077,6 +8329,12 @@ packages:
 
   /yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+    dev: true
+
+  /yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
     dev: true


### PR DESCRIPTION
## 📝 **PR Description**

### 🎯 **Overview**

`Field` was the one component in the package that could not be rendered from a React Server Component, and nothing said so. This PR fixes that, puts the release process on Changesets so the version number stops being decided from memory, and clears four bugs on the documentation site — three of which turned out to have the same root cause.

### ✨ **Key Features**

#### 1. **`Field.Control` accepts an element**

- **The bug**: `Field.Control` took a render function. React refuses functions across the server boundary — *"Functions cannot be passed directly to Client Components"* — so `Field` could not be rendered from a server component at all. The package README claimed the opposite: that a namespace import works on either side of the boundary. It does; `Field.Control` was what stopped there.
- **The fix**: `packages/components/react/src/field/index.tsx` now accepts a single element as well, and clones the generated props onto it. The element's own props win the merge, so a caller who writes `disabled` or an `id` keeps it and one who does not takes the field's.
- **The render prop is unchanged** and stays the form the documentation shows first. It is the only thing that works for a control the system has never seen, since cloning guesses at the child's API.
- **Documented**: `apps/docs/app/components/field/content.tsx` gains a "From a server component" example and a callout saying which form to reach for when.
- **Found by** building a consumer application outside the workspace and rendering every component from a server component. Verified there: the label's `for` matches the input's `id`, and `required` survives the clone.

#### 2. **Releases described by Changesets**

- **The problem**: 1.1.0 went out by hand — work out which packages changed, decide a bump for each, edit three `package.json` files, tag, publish. The version number was a decision made at release time from whatever anyone remembered of the week.
- **The fix**: `@changesets/cli` and three scripts — `pnpm changeset` writes one, `pnpm version-packages` spends them and writes the changelogs, `pnpm release` builds and publishes whatever moved.
- **The property worth keeping**: `base-react` and `behavior-react` had no changes in 1.1.0 and were not republished. That now holds without anyone remembering it — a package with no changeset gets no version, and a package that only depends on one that moved gets the bump `updateInternalDependencies` asks for.
- **The procedure is written down** in `.changeset/README.md`, including both tag styles: per-package tags say which package is at which version, and one repository tag is what a GitHub Release hangs on.
- **This PR carries one changeset**: `components-react` minor, for the `Field.Control` change above.

#### 3. **Focus rings follow the theme again**

- **The bug**: the docs site's `:focus-visible` rule set a `border-radius`. No component in the system redeclares a radius inside its own `:focus` rule — they declare it once and expect it to hold — so this rule had no competitor and won. An input at `radius="full"` went from a pill to a 4px rectangle the moment it took focus, and every other control lost its corners the same way.
- **The fix**: the radius is gone, and the selector is `:where(:focus-visible)`. A bare `:focus-visible` counts the same as a component's class, and the component bundle arrives through an `@import` at the top of the same file — so on a tie the site won, and a menu row that sets `outline: none` because highlighting is its focus indicator got an outline anyway. At zero specificity the rule is what it was meant to be: a floor for the site's own bare elements.

#### 4. **Toolbar dials hold their width, and their rings are whole**

- **Width**: `Select`'s trigger is `width: 100%`, which fills a block parent and means nothing in a flex row — there it falls back to its content, so the dial grew and shrank as its value went from `none` to `medium` and every control to the right of it moved. Styling the trigger directly is a fight a consumer loses: one class ties with the component's own, and the package's stylesheet is read last. A wrapper element sidesteps both, and the trigger fills it because filling its parent is what it already does.
- **Clipping**: the row scrolls, so it clips at its own edges. Every control there draws focus with a 2px outline offset inward by one, putting a pixel outside the element — and on the last dial that pixel was cut off. Four pixels of inline padding, matching the block padding already present for the same reason on the other axis, with a negative margin handing them back so the row sits where it always did.

#### 5. **Scroll position and specimen spacing**

- **`apps/docs/site/ScrollReset.tsx`**: Next resets the *window's* scroll between routes, and the window is not what scrolls here — `.main` is the scroll container, so the article kept whatever offset the last page left it at. It finds the container by walking up from its own node rather than by id, so the day the layout changes which element scrolls, this follows. `useLayoutEffect`, because in an effect the new page shows at the old offset for a frame first.
- **`apps/docs/site/tokens.module.css`**: the type specimen rows go from `align-items: baseline` to `center`, and the meta gap from 2px to 6px. The chip above carries two pixels of its own padding, so a two-pixel gap put its box within four of the line under it and the pair read as one smudged block rather than as a name and its measurement.

### 🔧 **Technical Details**

- **Dependencies**: `@changesets/cli` ^3.0.0, as a root devDependency.
- **Breaking changes**: none. `Field.Control`'s render-function form is untouched; the element form is additive, which is why the changeset is a minor.
- **Pending release**: `components-react` 1.1.0 → 1.2.0 when the changeset is spent. No other package has a changeset, so no other package moves.

### 🧪 **Testing**

- [x] Manual testing completed — every component rendered from a server component in a consumer application outside the workspace
- [x] Build successful (`pnpm build:packages`, `pnpm --filter docs build` — 38/38 pages)
- [x] Type check passed
- [x] Lint check passed (`pnpm lint`, `prettier --check`)
- [x] Invariant suite passed (`pnpm test` — reads `dist`, not `src`)
